### PR TITLE
Bugfix/#31 urlliberrorurlerror raised when executing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 build:
 	poetry run python build_system/update_version.py
-	poetry run pyinstaller --hidden-import certifi --onefile ./src/redownload_cli.py --name redownload-cli
+	poetry run pyinstaller --onefile ./src/redownload_cli.py --name redownload-cli

--- a/src/redownload/downloads.py
+++ b/src/redownload/downloads.py
@@ -25,7 +25,7 @@ def download_from_set(urls: set, out_dir: str) -> None:
     for url in urls:
         filename = url[url.rfind("/") + 1 : len(url)]
         print(f"Beginning to download '{filename}'")
-        with requests.get(url, stream=True, cert=certifi.where()) as response:
+        with requests.get(url, stream=True) as response:
             with open(os.path.join(out_dir, filename), "xb") as file:
                 for chunk in response.iter_content(512):
                     file.write(chunk)

--- a/src/redownload/downloads.py
+++ b/src/redownload/downloads.py
@@ -1,5 +1,6 @@
 import os
 
+import certifi # To fix SSL issue from issue #31
 import requests
 
 from . import exceptions
@@ -24,7 +25,7 @@ def download_from_set(urls: set, out_dir: str) -> None:
     for url in urls:
         filename = url[url.rfind("/") + 1 : len(url)]
         print(f"Beginning to download '{filename}'")
-        with requests.get(url, stream=True) as response:
+        with requests.get(url, stream=True, cert=certifi.where()) as response:
             with open(os.path.join(out_dir, filename), "xb") as file:
                 for chunk in response.iter_content(512):
                     file.write(chunk)

--- a/src/redownload/downloads.py
+++ b/src/redownload/downloads.py
@@ -1,6 +1,5 @@
 import os
 
-import certifi # To fix SSL issue from issue #31
 import requests
 
 from . import exceptions

--- a/src/redownload/web_parsing.py
+++ b/src/redownload/web_parsing.py
@@ -14,7 +14,7 @@ def html_from_url(url: str) -> bs4.BeautifulSoup:
     :param url: The URL to download HTML from, in a string.
     :return: BeautifulSoup object extracted from the url.
     """
-    request = urllib.request.urlopen(urllib.request.Request(url, headers={"User-Agent": "Mozilla"}))
+    request = urllib.request.urlopen(urllib.request.Request(url, headers={"User-Agent": "Mozilla"}), cafile=certifi.where())
     html_doc = request.read()
     html_soup = bs4.BeautifulSoup(html_doc, features="html.parser")
     return html_soup

--- a/src/redownload/web_parsing.py
+++ b/src/redownload/web_parsing.py
@@ -3,6 +3,7 @@ import urllib.parse
 import urllib.request
 
 import bs4
+import certifi  # To fix SSL issue from issue #31
 
 from . import exceptions
 


### PR DESCRIPTION
## Describe Your Changes:
- Fixed a bug causing a urllib.error.urlerror when executing from a build on macos

### Linked Issues:
Closes #31 

## Change Type
### Category
- [x] This is a Bugfix
- [ ] This is a Feature Addition
- [ ] This is a CI Change
- [ ] This is a Documentation-Only Change (do not check any of the above boxes if this box is checked)
### Breaking/Non Breaking
- [ ] This is a Breaking Change
- [x] This is a Non-Breaking Change